### PR TITLE
大佬，发现您的项目引入了mysql:mysql-connector-java@8.0.26组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -26,7 +25,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.26</version>
+			<version>8.0.28</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：MySQL JDBC XXE漏洞
缺陷组件：mysql:mysql-connector-java@8.0.26
漏洞编号：CVE-2021-2471
漏洞描述：Oracle MySQL是美国甲骨文（Oracle）公司的一套开源的关系数据库管理系统。
Oracle MySQL 的 MySQL Connectors 产品中存在输入验证错误漏洞，该漏洞允许高特权攻击者通过多种协议访问网络来破坏 MySQL 连接器。成功攻击此漏洞会导致对关键数据的未授权访问或对所有 MySQL 连接器可访问数据的完全访问，以及导致 MySQL 连接器挂起或频繁重复崩溃。
影响范围：(∞, 8.0.27)
最小修复版本：8.0.28
缺陷组件引入路径：com.jay:ue4_login@0.0.1-SNAPSHOT->mysql:mysql-connector-java@8.0.26
```
另外我运行这个项目时，IDE的安全插件提示还有几个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p4b143